### PR TITLE
Drata Compliance Recommendations (Grouped)

### DIFF
--- a/aws::elasticache::cachecluster/main.tf
+++ b/aws::elasticache::cachecluster/main.tf
@@ -4,6 +4,7 @@
 # ElastiCache
 # ---------------------------------------------------------------------
 resource "aws_elasticache_cluster" "sac_memcached_cluster" {
+  # Drata: Default network security groups allow broader access than required. Specify [aws_elasticache_cluster.security_group_ids] to configure more granular access control
   cluster_id               = "sac-testing-memcached-cluster"
   engine                   = "memcached"
   node_type                = "cache.t3.small"


### PR DESCRIPTION
## Drata identified 2 design gaps in 2 resources


View your full validation results in [Drata](https://app-04.dev.drata.com/compliance/monitoring/code)
| Test                    | Summary |
| ----------- | ---------- |
| Autoscaling Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Backup Retention Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Transparent Data-at-Rest Encryption Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Cloud Storage Versioning Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Zone Redundancy Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Logging Configuration Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Secure TLS/SSL Configuration | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| VPC Configuration | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| TLS Enforced | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Security Groups Configured | `Critical: 0  High: 0  Moderate: 2  Low: 0  ` |
| Network Configurations Restrict Broad Access | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Public Access Restricted | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Network Access Denied By Default | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
### Remediated (1)
Remediate these design gaps by merging this pull request.
 
| Severity    | Resource Name                    | Fix |
| ------------- | --------------------------- | ---------- |
| Moderate | `sac_memcached_cluster` | # Drata: Default network security groups allow broader access than required. Specify [aws_elasticache_cluster.security_group_ids] to configure more granular access control<br> |
| Moderate | `sac_redis_cluster` | # Drata: Default network security groups allow broader access than required. Specify [aws_elasticache_cluster.security_group_ids] to configure more granular access control<br> |
