### PR TITLE
Drata Compliance Recommendations (Grouped)

### DIFF
--- a/aws::ec2::securitygroup/main.tf
+++ b/aws::ec2::securitygroup/main.tf
@@ -38,6 +38,7 @@ resource "aws_security_group" "sac_security_group" {
     to_port          = 4
     protocol         = "tcp"         # SaC Testing - Severity: Low - Set protocol to -1
     cidr_blocks      = ["0.0.0.0/0"] # SaC Testing - Severity: Low - Set cidr_blocks to undefined
+    # Drata: Ensure that [aws_security_group.ingress.cidr_blocks] is explicitly defined and narrowly scoped to only allow traffic from trusted sources
     # Drata: Ensure that [aws_security_group.egress.ipv6_cidr_blocks] is explicitly defined and narrowly scoped to only allow traffic to trusted sources
     # Drata: Ensure that [aws_security_group.egress.cidr_blocks] is explicitly defined and narrowly scoped to only allow traffic to trusted sources
     ipv6_cidr_blocks = ["::/0"]      # SaC Testing - Severity: Low - Set ipv6_cidr_blocks to undefined


### PR DESCRIPTION
## Drata identified 1 design gap in 1 resource


View your full validation results in [Drata](https://app-04.dev.drata.com/compliance/monitoring/code)
| Test                    | Summary |
| ----------- | ---------- |
| Autoscaling Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Backup Retention Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Transparent Data-at-Rest Encryption Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Cloud Storage Versioning Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Zone Redundancy Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Logging Configuration Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Secure TLS/SSL Configuration | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| VPC Configuration | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| TLS Enforced | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Security Groups Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Network Configurations Restrict Broad Access | `Critical: 0  High: 1  Moderate: 2  Low: 0  ` |
| Public Access Restricted | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Network Access Denied By Default | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
### Remediated (1)
Remediate these design gaps by merging this pull request.
 
| Severity    | Resource Name                    | Fix |
| ------------- | --------------------------- | ---------- |
| Moderate | `sac_security_group` | # Drata: Ensure that [aws_security_group.egress.cidr_blocks] is explicitly defined and narrowly scoped to only allow traffic to trusted sources<br> # Drata: Ensure that [aws_security_group.egress.ipv6_cidr_blocks] is explicitly defined and narrowly scoped to only allow traffic to trusted sources<br> # Drata: Ensure that [aws_security_group.ingress.cidr_blocks] is explicitly defined and narrowly scoped to only allow traffic from trusted sources<br> |
