### PR TITLE
Drata Compliance Recommendations (Grouped)

### DIFF
--- a/aws::elasticloadbalancingv2/main.tf
+++ b/aws::elasticloadbalancingv2/main.tf
@@ -7,7 +7,7 @@ resource "aws_lb" "elbv2_sac" {
   load_balancer_type         = "application"
   drop_invalid_header_fields = true      # SaC Testing - Severity:  - Set drop_invalid_header_fields to true
   desync_mitigation_mode     = "monitor" # SaC Testing - Severity:  - Set desync_mitigation_mode != ['defensive', 'strictest']
-  internal                   = false     # SaC Testing - Severity: Critical - Set internal to false/undefined
+  internal                   = true
   enable_deletion_protection = false     # SaC Testing - Severity: Moderate - Set enable_deletion_protection to undefined
   #security_groups = [aws_security_group.ec2_instance_security_group_default.id]  # SaC Testing - Severity: Moderate - Set security_groups to undefined
   # SaC Testing - Severity: Moderate - Set tags to undefined


### PR DESCRIPTION
## Drata identified 1 design gap in 1 resource


View your full validation results in [Drata](https://app-04.dev.drata.com/compliance/monitoring/code)
| Test                    | Summary |
| ----------- | ---------- |
| Autoscaling Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Backup Retention Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Transparent Data-at-Rest Encryption Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Cloud Storage Versioning Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Zone Redundancy Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Logging Configuration Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Secure TLS/SSL Configuration | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| VPC Configuration | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| TLS Enforced | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Security Groups Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Network Configurations Restrict Broad Access | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Public Access Restricted | `Critical: 0  High: 1  Moderate: 0  Low: 0  ` |
| Network Access Denied By Default | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
### Remediated (1)
Remediate these design gaps by merging this pull request.
 
| Severity    | Resource Name                    | Fix |
| ------------- | --------------------------- | ---------- |
| High | `elbv2_listener` | Configure [aws_lb.internal] to true to disable public access. It is recommended to explicitly allow access to trusted users or IPs. Ignore this finding if your business use-case requires ELB V2 to be publicly available<br> |
