### PR TITLE
Drata Compliance Recommendations (Grouped)

### DIFF
--- a/aws::s3/main.tf
+++ b/aws::s3/main.tf
@@ -63,7 +63,7 @@ EOF
 
 resource "aws_s3_bucket_public_access_block" "s3_public_access_block_sac" { # SaC Testing - Severity: Critical - Set aws_s3_bucket_public_access_block to undefined
   bucket                  = aws_s3_bucket.s3_bucket_sac.id
-  block_public_acls       = false # SaC Testing - Severity: Critical - Set block_public_acls to false
+  block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true


### PR DESCRIPTION
## Drata identified 1 design gap in 1 resource


View your full validation results in [Drata](https://app-04.dev.drata.com/compliance/monitoring/code)
| Test                    | Summary |
| ----------- | ---------- |
| Autoscaling Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Backup Retention Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Transparent Data-at-Rest Encryption Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Cloud Storage Versioning Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Zone Redundancy Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Logging Configuration Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Secure TLS/SSL Configuration | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| VPC Configuration | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| TLS Enforced | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Security Groups Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Network Configurations Restrict Broad Access | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Public Access Restricted | `Critical: 0  High: 4  Moderate: 0  Low: 0  ` |
| Network Access Denied By Default | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
### Remediated (1)
Remediate these design gaps by merging this pull request.
 
| Severity    | Resource Name                    | Fix |
| ------------- | --------------------------- | ---------- |
| High | `s3_bucket_sac` | Set [aws_s3_bucket_public_access_block.ignore_public_acls] to true to prevent intentional or incidental public access<br> Set [aws_s3_bucket_public_access_block.block_public_acls] to true to prevent intentional or incidental public access<br> Set [aws_s3_bucket_public_access_block.block_public_policy] to true to prevent intentional or incidental public access. Ignore this finding if this configuration is set at the account level<br> Set [aws_s3_bucket_public_access_block.restrict_public_buckets] to true to prevent intentional or incidental public access. Setting this field ensures bucket access is limited to AWS service principals and authorized users. Ignore this finding if this configuration is set at the account level<br> |
