### PR TITLE
Drata Compliance Recommendations (Grouped)

### DIFF
--- a/microsoft.sql.servers/main.tf
+++ b/microsoft.sql.servers/main.tf
@@ -16,7 +16,7 @@ resource "azurerm_mssql_server" "sac_mssql_server" {
   administrator_login           = "msuch-oak9"
   administrator_login_password  = "$uPer$ecure$ecret!234"
   minimum_tls_version           = "1.1" # SaC Testing - Severity: Critical - Set minimum_tls_version != 1.2
-  public_network_access_enabled = true  # SaC Testing - Severity: High - Set public_network_access_enabled to true
+  public_network_access_enabled = false
   # SaC Testing - Severity: Moderate - Set tags to undefined
   # tags = {
   #   environment = "production"


### PR DESCRIPTION
## Drata identified 1 design gap in 1 resource


View your full validation results in [Drata](https://app-04.dev.drata.com/compliance/monitoring/code)
| Test                    | Summary |
| ----------- | ---------- |
| Autoscaling Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Backup Retention Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Transparent Data-at-Rest Encryption Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Cloud Storage Versioning Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Zone Redundancy Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Logging Configuration Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Secure TLS/SSL Configuration | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| VPC Configuration | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| TLS Enforced | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Security Groups Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Network Configurations Restrict Broad Access | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Public Access Restricted | `Critical: 0  High: 1  Moderate: 0  Low: 0  ` |
| Network Access Denied By Default | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
### Remediated (1)
Remediate these design gaps by merging this pull request.
 
| Severity    | Resource Name                    | Fix |
| ------------- | --------------------------- | ---------- |
| High | `elasticpool` | Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs<br> |
