### PR TITLE
Drata Compliance Recommendations (Grouped)

### DIFF
--- a/google_sql/main.tf
+++ b/google_sql/main.tf
@@ -21,6 +21,7 @@ resource "google_sql_database_instance" "sac_sql_db_instance" {
     }
     backup_configuration {
       enabled                        = false # SaC Testing - Severity: Moderate - set enabled to False
+      # Drata: Ensure that SQL database instance is not publicly accessible by giving it a private IP. Define [google_sql.sql_database_instance.settings.ip_configuration.private_network] to use private IPs while connecting to SQL database instance
       point_in_time_recovery_enabled = false # SaC Testing - Severity: Moderate - set point_in_time_recovery_enabled to False
     }
   }


### PR DESCRIPTION
## Drata identified 1 design gap in 1 resource


View your full validation results in [Drata](https://app-04.dev.drata.com/compliance/monitoring/code)
| Test                    | Summary |
| ----------- | ---------- |
| Autoscaling Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Backup Retention Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Transparent Data-at-Rest Encryption Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Cloud Storage Versioning Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Zone Redundancy Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Logging Configuration Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Secure TLS/SSL Configuration | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| VPC Configuration | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| TLS Enforced | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Security Groups Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Network Configurations Restrict Broad Access | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Public Access Restricted | `Critical: 0  High: 0  Moderate: 1  Low: 0  ` |
| Network Access Denied By Default | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
### Remediated (1)
Remediate these design gaps by merging this pull request.
 
| Severity    | Resource Name                    | Fix |
| ------------- | --------------------------- | ---------- |
| Moderate | `sac_sql_db` | # Drata: Ensure that SQL database instance is not publicly accessible by giving it a private IP. Define [google_sql.sql_database_instance.settings.ip_configuration.private_network] to use private IPs while connecting to SQL database instance<br> |
