### PR TITLE
Drata Compliance Recommendations (Grouped)

### DIFF
--- a/microsoft.keyvault/main.tf
+++ b/microsoft.keyvault/main.tf
@@ -20,7 +20,7 @@ resource "azurerm_key_vault" "sac_key_vault" {
   public_network_access_enabled = true       # SaC Testing - Severity: High - set public_network_access_enabled to true
   network_acls {
     bypass         = "AzureServices"
-    default_action = "Allow" # SaC Testing - Severity: Critical - set defualt_action != deny
+    default_action = "Deny"
   }
   # SaC Testing - Severity: Moderate - Set tags to undefined
   # tags = {


### PR DESCRIPTION
## Drata identified 1 design gap in 1 resource


View your full validation results in [Drata](https://app-04.dev.drata.com/compliance/monitoring/code)
| Test                    | Summary |
| ----------- | ---------- |
| Autoscaling Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Backup Retention Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Transparent Data-at-Rest Encryption Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Cloud Storage Versioning Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Zone Redundancy Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Logging Configuration Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Secure TLS/SSL Configuration | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| VPC Configuration | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| TLS Enforced | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Security Groups Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Network Configurations Restrict Broad Access | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Public Access Restricted | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Network Access Denied By Default | `Critical: 1  High: 0  Moderate: 0  Low: 0  ` |
### Remediated (1)
Remediate these design gaps by merging this pull request.
 
| Severity    | Resource Name                    | Fix |
| ------------- | --------------------------- | ---------- |
| Critical | `sac_key_vault` | Configure [azurerm_key_vault.network_acls.default_action] to Deny to deny all traffic by default. Only allow traffic to Key Vault through IP rules or Virtual Network rules<br> |
