### PR TITLE
Drata Compliance Recommendations (Grouped)

### DIFF
--- a/aws::elasticache::cachecluster/main.tf
+++ b/aws::elasticache::cachecluster/main.tf
@@ -30,6 +30,7 @@ resource "aws_elasticache_cluster" "sac_redis_cluster" {
   port                     = 6379 # SaC Testing - Severity: Low - set port to default (6379)
   subnet_group_name        = aws_elasticache_subnet_group.elasticache_subnet_group.name
   snapshot_retention_limit = 0 # SaC Testing - Severity: Moderate - set snapshot_retention_limit = 0
+  # Drata: Specify [aws_elasticache_cluster.snapshot_retention_limit] to ensure sensitive data is only available when necessary. Setting snapshot retention to 0 will disable automatic backups
   #security_group_ids = [aws_security_group.cluster_security_group.id]  # SaC Testing - Severity: Moderate - set security_group_ids to undefined
   # SaC Testing - Severity: Moderate - set tags to undefined
   # tags = {


### PR DESCRIPTION
## Drata identified 1 design gap in 1 resource


View your full validation results in [Drata](https://app-04.dev.drata.com/compliance/monitoring/code)
| Test                    | Summary |
| ----------- | ---------- |
| Autoscaling Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Backup Retention Configured | `Critical: 0  High: 0  Moderate: 1  Low: 0  ` |
| Transparent Data-at-Rest Encryption Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Cloud Storage Versioning Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Zone Redundancy Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Logging Configuration Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Secure TLS/SSL Configuration | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| VPC Configuration | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| TLS Enforced | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Security Groups Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Network Configurations Restrict Broad Access | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Public Access Restricted | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Network Access Denied By Default | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Automatic Software Updates | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Log Integrity | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Strong TLS Ciphers | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Web Application Firewall | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Automated Backups | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Secure API Version | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Log Retention | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Default Service Accounts Disabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
### Remediated (1)
Remediate these design gaps by merging this pull request.
 
| Severity    | Resource Name                    | Fix |
| ------------- | --------------------------- | ---------- |
| Moderate | `sac_redis_cluster` | # Drata: Specify [aws_elasticache_cluster.snapshot_retention_limit] to ensure sensitive data is only available when necessary. Setting snapshot retention to 0 will disable automatic backups<br> |
