### PR TITLE
Drata Compliance Recommendations (Grouped)

### DIFF
--- a/microsoft.cache/main.tf
+++ b/microsoft.cache/main.tf
@@ -15,7 +15,7 @@ resource "azurerm_redis_cache" "sac_redis_cache" {
   capacity            = 1
   family              = "P"
   sku_name            = "Premium"
-  enable_non_ssl_port = true  # SaC Testing - Severity: Critical/High - set enable_non_ssl_port to true
+  enable_non_ssl_port = false
   minimum_tls_version = "1.0" # SaC Testing - Severity: Critical - set minimum_tls_version to 1.0 or 1.1 
   # replicas_per_master       = 2 # SaC Testing - Severity: Moderate - set replicas_per_master to undefined
   # zones = ["2"] # SaC Testing - Severity: Moderate - set zones to undefined


### PR DESCRIPTION
## Drata identified 1 design gap in 1 resource


View your full validation results in [Drata](https://app-04.dev.drata.com/compliance/monitoring/code)
| Test                    | Summary |
| ----------- | ---------- |
| Autoscaling Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Backup Retention Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Transparent Data-at-Rest Encryption Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Cloud Storage Versioning Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Zone Redundancy Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Logging Configuration Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Secure TLS/SSL Configuration | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| VPC Configuration | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| TLS Enforced | `Critical: 1  High: 0  Moderate: 0  Low: 0  ` |
| Security Groups Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Network Configurations Restrict Broad Access | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Public Access Restricted | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Network Access Denied By Default | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Automatic Software Updates | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Log Integrity | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Strong TLS Ciphers | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Web Application Firewall | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Automated Backups | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Secure API Version | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Log Retention | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Default Service Accounts Disabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
### Remediated (1)
Remediate these design gaps by merging this pull request.
 
| Severity    | Resource Name                    | Fix |
| ------------- | --------------------------- | ---------- |
| Critical | `sac_redis_cache` | Set [azurerm_redis_cache.enable_non_ssl_port] to false to ensure secure protocols are being used to encrypt resource traffic<br> |
