### PR TITLE
Drata Compliance Recommendations (Grouped)

### DIFF
--- a/microsoft.containerservice/main.tf
+++ b/microsoft.containerservice/main.tf
@@ -44,7 +44,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "sac_aks_node_pool" {
   name                  = "sacakspool"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.sac_aks_cluster.id
   vm_size               = "Standard_DS2_v2"
-  enable_node_public_ip = true # SaC Testing - Severity: Critical - Set enable_node_public_ip to true
+  enable_node_public_ip = false
   #zones = [2,1]  # SaC Testing - Severity: High - Set zones to []
   enable_auto_scaling = false # SaC Testing - Severity: High - Set enable_auto_scaling to false
   max_count           = 100


### PR DESCRIPTION
## Drata identified 1 design gap in 1 resource


View your full validation results in [Drata](https://app-04.dev.drata.com/compliance/monitoring/code)
| Test                    | Summary |
| ----------- | ---------- |
| Autoscaling Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Backup Retention Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Transparent Data-at-Rest Encryption Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Cloud Storage Versioning Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Zone Redundancy Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Logging Configuration Enabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Secure TLS/SSL Configuration | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| VPC Configuration | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| TLS Enforced | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Security Groups Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Network Configurations Restrict Broad Access | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Public Access Restricted | `Critical: 0  High: 0  Moderate: 1  Low: 0  ` |
| Network Access Denied By Default | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Automatic Software Updates | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Log Integrity | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Strong TLS Ciphers | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Web Application Firewall | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Automated Backups | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Secure API Version | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Log Retention | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Default Service Accounts Disabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
### Remediated (1)
Remediate these design gaps by merging this pull request.
 
| Severity    | Resource Name                    | Fix |
| ------------- | --------------------------- | ---------- |
| Moderate | `sac_aks_node_pool` | Set [azurerm_kubernetes_cluster_node_pool.enable_node_public_ip] to false to prevent the automatic assignment of public IP addresses to AKS Cluster Nodes<br> |
